### PR TITLE
Add year range with current year, remove Google+

### DIFF
--- a/partials/footer.html
+++ b/partials/footer.html
@@ -1,4 +1,4 @@
-<p>© <span id="year">2017</span> Daniel Foré. Made in California.</p>
+<p>© <span id="year">2016–2019</span> Daniel Foré. Made in California.</p>
 <ul>
     <li class="animated pink">
         <a href="https://dribbble.com/danrabbit" class="tooltip" data-tooltip="Dribbble" target="_blank">
@@ -8,11 +8,6 @@
     <li class="animated black">
         <a href="https://github.com/danrabbit" class="tooltip" data-tooltip="GitHub" target="_blank">
             <i class="fa fa-github fa-lg"></i>
-        </a>
-    </li>
-    <li class="animated red">
-        <a href="https://plus.google.com/+DanielForé" class="tooltip" data-tooltip="Google+" target="_blank">
-            <i class="fa fa-google-plus fa-lg"></i>
         </a>
     </li>
     <li class="animated instagram">


### PR DESCRIPTION
Websites with changing content should include a year range instead of a single year (which would be earliest publication, not latest). Remove Google+ as it's gonna be dead in a month.